### PR TITLE
Implement filter for Main / Author Area which by default excludes. 

### DIFF
--- a/cms-publish-config/src/main/java/se/simonsoft/cms/publish/config/databinds/config/PublishConfig.java
+++ b/cms-publish-config/src/main/java/se/simonsoft/cms/publish/config/databinds/config/PublishConfig.java
@@ -28,6 +28,7 @@ public class PublishConfig {
 	protected List<String> typeInclude;
 	protected Boolean profilingInclude;
 	protected List<String> profilingNameInclude = null; // No array means include all profiling recipes.
+	protected boolean areaMainInclude = false; // Disable Main / Author area by default.
 	private List<PublishConfigArea> areas = new ArrayList<PublishConfigArea>();
 	private PublishConfigOptions options;
 	
@@ -77,6 +78,12 @@ public class PublishConfig {
 	}
 	public void setProfilingNameInclude(List<String> profilingInclude) {
 		this.profilingNameInclude = profilingInclude;
+	}
+	public boolean isAreaMainInclude() {
+		return this.areaMainInclude;
+	}
+	public void setAreaMainInclude(boolean areaMainInclude) {
+		this.areaMainInclude = areaMainInclude;
 	}
 	public List<PublishConfigArea> getAreas() {
 		return areas;

--- a/cms-publish-config/src/main/java/se/simonsoft/cms/publish/config/databinds/job/PublishJob.java
+++ b/cms-publish-config/src/main/java/se/simonsoft/cms/publish/config/databinds/job/PublishJob.java
@@ -49,6 +49,7 @@ public class PublishJob extends PublishConfig implements WorkflowItemInput{
 		this.typeInclude = pj.getTypeInclude();
 		this.profilingInclude = pj.getProfilingInclude();
 		this.profilingNameInclude = pj.getProfilingNameInclude();
+		this.areaMainInclude = pj.isAreaMainInclude();
 	}
 	
 	public PublishJob(PublishConfig pc) {
@@ -61,6 +62,7 @@ public class PublishJob extends PublishConfig implements WorkflowItemInput{
 		this.typeInclude = pc.getTypeInclude();
 		this.profilingInclude = pc.getProfilingInclude();
 		this.profilingNameInclude = pc.getProfilingNameInclude();
+		this.areaMainInclude = pc.isAreaMainInclude();
 	}
 	
 	public PublishJob() {

--- a/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/config/filter/PublishConfigFilterAreaMain.java
+++ b/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/config/filter/PublishConfigFilterAreaMain.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2009-2017 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.publish.rest.config.filter;
+
+import se.simonsoft.cms.item.CmsItem;
+import se.simonsoft.cms.publish.config.databinds.config.PublishConfig;
+import se.simonsoft.cms.publish.config.item.CmsItemPublish;
+
+public class PublishConfigFilterAreaMain implements PublishConfigFilter {
+
+	
+	@Override
+	public boolean accept(PublishConfig config, CmsItem item) {
+		
+		if (!(item instanceof CmsItemPublish)) {
+			return false;
+		}
+		
+		CmsItemPublish itemPublish = (CmsItemPublish) item;
+		
+		if (itemPublish.isRelease()) {
+			return true; // Always include Release.
+		} else if (itemPublish.isTranslation()) {
+			return true; // Always include Translation.
+		} else {
+			return config.isAreaMainInclude(); // Include Main / Author area if configured.
+		}
+	}
+
+}

--- a/cms-publish-rest/src/test/java/se/simonsoft/cms/publish/rest/config/filter/PublishConfigFilterTest.java
+++ b/cms-publish-rest/src/test/java/se/simonsoft/cms/publish/rest/config/filter/PublishConfigFilterTest.java
@@ -109,6 +109,64 @@ public class PublishConfigFilterTest {
 		assertTrue(filter.accept(publishConfig, null));
 	}
 	
+	
+	@Test
+	public void testAreaMainFilterDefault() throws Exception {
+		PublishConfig publishConfig = getConfigJsonTestData(pathConfigSimple);
+		PublishConfigFilter filter = new PublishConfigFilterAreaMain();
+		
+		CmsItem itemMock = mock(CmsItem.class);
+		CmsItemPropertiesMap props = new CmsItemPropertiesMap("cms:status", "Released");
+		when(itemMock.getProperties()).thenReturn(props);
+		assertFalse(new CmsItemPublish(itemMock).isRelease());
+		assertFalse(filter.accept(publishConfig, new CmsItemPublish(itemMock)));
+		
+		CmsItem itemMockRelease = mock(CmsItem.class);
+		CmsItemPropertiesMap propsRelease = new CmsItemPropertiesMap("cms:status", "Released");
+		propsRelease.and("abx:ReleaseLabel", "B");
+		propsRelease.and("abx:AuthorMaster", "Bogus");
+		propsRelease.and("abx:ReleaseMaster", "Bogus");
+		when(itemMockRelease.getProperties()).thenReturn(propsRelease);
+		assertTrue(new CmsItemPublish(itemMockRelease).isRelease());
+		assertTrue(filter.accept(publishConfig, new CmsItemPublish(itemMockRelease)));
+		itemMockRelease = null;
+		propsRelease = null;
+		
+		CmsItem itemMockTranslation = mock(CmsItem.class);
+		CmsItemPropertiesMap propsTranslation = new CmsItemPropertiesMap("cms:status", "Released");
+		propsTranslation.and("abx:ReleaseLabel", "B");
+		propsTranslation.and("abx:TranslationLocale", "de-DE");
+		propsTranslation.and("abx:AuthorMaster", "Bogus");
+		propsTranslation.and("abx:TranslationMaster", "Bogus");
+		when(itemMockTranslation.getProperties()).thenReturn(propsTranslation);
+		assertFalse(new CmsItemPublish(itemMockTranslation).isRelease());
+		assertTrue(new CmsItemPublish(itemMockTranslation).isTranslation());
+		assertTrue(filter.accept(publishConfig, new CmsItemPublish(itemMockTranslation)));
+	}
+	
+	
+	@Test
+	public void testAreaMainFilterInclude() throws Exception {
+		PublishConfig publishConfig = getConfigJsonTestData(pathConfigType);
+		PublishConfigFilter filter = new PublishConfigFilterAreaMain();
+		
+		CmsItem itemMock = mock(CmsItem.class);
+		CmsItemPropertiesMap props = new CmsItemPropertiesMap("cms:status", "Released");
+		when(itemMock.getProperties()).thenReturn(props);
+		assertFalse(new CmsItemPublish(itemMock).isRelease());
+		assertTrue(filter.accept(publishConfig, new CmsItemPublish(itemMock)));
+		
+		CmsItem itemMockRelease = mock(CmsItem.class);
+		CmsItemPropertiesMap propsRelease = new CmsItemPropertiesMap("cms:status", "Released");
+		propsRelease.and("abx:ReleaseLabel", "B");
+		propsRelease.and("abx:AuthorMaster", "Bogus");
+		propsRelease.and("abx:ReleaseMaster", "Bogus");
+		when(itemMockRelease.getProperties()).thenReturn(propsRelease);
+		assertTrue(new CmsItemPublish(itemMockRelease).isRelease());
+		assertTrue(filter.accept(publishConfig, new CmsItemPublish(itemMockRelease)));
+	}
+	
+	
 	@Test
 	public void testTypeFilter() throws Exception {
 		PublishConfig publishConfig = getConfigJsonTestData(pathConfigType);

--- a/cms-publish-rest/src/test/resources/se/simonsoft/cms/publish/config/filter/publish-config-type.json
+++ b/cms-publish-rest/src/test/resources/se/simonsoft/cms/publish/config/filter/publish-config-type.json
@@ -2,6 +2,7 @@
   "active": true,
   "visible": true,
   "typeInclude": ["operator", "service"],
+  "areaMainInclude": true,
   "areas": [
     {
         "pathnameTemplate": "DOC_${item.getId().getRelPath().getNameBase()}.pdf"


### PR DESCRIPTION
Enables setting publish config on project level without including Author Area.