### PR TITLE
Versions info

### DIFF
--- a/cms-publish-worker-webapp/pom.xml
+++ b/cms-publish-worker-webapp/pom.xml
@@ -101,6 +101,13 @@
 		</dependency>
 		<!-- uncomment this to get JSON support <dependency> <groupId>org.glassfish.jersey.media</groupId> 
 			<artifactId>jersey-media-json-binding</artifactId> </dependency> -->
+			
+		<dependency>
+			<groupId>se.simonsoft</groupId>
+			<artifactId>cms-versioninfo</artifactId>
+			<version>1.3.1</version>
+		</dependency>
+		
 		<dependency>
 			<groupId>se.simonsoft</groupId>
 			<artifactId>cms-publish-config</artifactId>
@@ -130,6 +137,12 @@
 			<artifactId>velocity-engine-core</artifactId>
 			<version>2.0</version>
 		</dependency>
+		
+		<dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
 	</dependencies>
 	
 	<properties>

--- a/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/VersionsResource.java
+++ b/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/VersionsResource.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2009-2017 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.publish.worker;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import se.simonsoft.cms.publish.worker.startup.WorkerApplication;
+import se.simonsoft.cms.version.CmsComponentVersion;
+import se.simonsoft.cms.version.CmsComponents;
+
+
+@Path("versions")
+public class VersionsResource {
+	
+	
+	private static final Logger logger = LoggerFactory.getLogger(VersionsResource.class);
+
+	@GET
+	@Produces(MediaType.TEXT_HTML)
+	public String getVersions() throws Exception {
+		VelocityEngine engine = new VelocityEngine();
+		Properties p = new Properties();
+		p.setProperty(RuntimeConstants.RESOURCE_LOADER, "class");
+		p.setProperty("runtime.references.strict", "true");
+		p.setProperty("class.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
+		engine.init(p);
+		
+		
+		VelocityContext context = new VelocityContext();
+		//Name of dep and version (String) defined in pom.xml
+		Map<String, String> versions = new HashMap<String, String>();
+		for (String name: CmsComponents.getNames()) {
+			CmsComponentVersion version = CmsComponents.getVersion(name);
+			versions.put(name, version.getVersion());
+		}
+		
+		context.put("depVersions", versions);
+		logger.debug("Versions webapp: {}", WorkerApplication.getWebappVersion().toString());
+		context.put("webappVersion", WorkerApplication.getWebappVersion().toString());
+		
+		Template template = engine.getTemplate("se/simonsoft/publish/worker/templates/VersionsTemplate.vm");
+		
+		StringWriter wr = new StringWriter();
+		template.merge(context, wr);
+		return wr.toString();
+	}
+	
+}

--- a/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/VersionsResource.java
+++ b/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/VersionsResource.java
@@ -17,8 +17,11 @@ package se.simonsoft.cms.publish.worker;
 
 import java.io.StringWriter;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -56,14 +59,16 @@ public class VersionsResource {
 		
 		VelocityContext context = new VelocityContext();
 		//Name of dep and version (String) defined in pom.xml
-		Map<String, String> versions = new HashMap<String, String>();
-		for (String name: CmsComponents.getNames()) {
+		Set<String> components = new TreeSet<String>();
+		components.addAll(CmsComponents.getNames());
+		
+		Map<String, String> versions = new LinkedHashMap<String, String>();
+		for (String name: components) {
 			CmsComponentVersion version = CmsComponents.getVersion(name);
 			versions.put(name, version.getVersion());
 		}
 		
 		context.put("depVersions", versions);
-		logger.debug("Versions webapp: {}", WorkerApplication.getWebappVersion().toString());
 		context.put("webappVersion", WorkerApplication.getWebappVersion().toString());
 		
 		Template template = engine.getTemplate("se/simonsoft/publish/worker/templates/VersionsTemplate.vm");

--- a/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/VersionsResource.java
+++ b/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/VersionsResource.java
@@ -37,7 +37,7 @@ import se.simonsoft.cms.version.CmsComponentVersion;
 import se.simonsoft.cms.version.CmsComponents;
 
 
-@Path("versions")
+@Path("info/version")
 public class VersionsResource {
 	
 	

--- a/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/startup/WorkerApplication.java
+++ b/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/startup/WorkerApplication.java
@@ -83,8 +83,9 @@ public class WorkerApplication extends ResourceConfig {
 
 	public WorkerApplication(@Context ServletContext context)  {
 		
-		logger.info("Worker Webapp starting with context: " + context);
 		this.context = context;
+		logger.info("Worker Webapp starting with context: " + context);
+		
 		setWebappVersion(context);
 		context.setAttribute("buildName", webappVersion.toString());
 		CmsComponents.logAllVersions();

--- a/cms-publish-worker-webapp/src/main/resources/se/simonsoft/publish/worker/templates/VersionsTemplate.vm
+++ b/cms-publish-worker-webapp/src/main/resources/se/simonsoft/publish/worker/templates/VersionsTemplate.vm
@@ -1,0 +1,36 @@
+#*
+ * Copyright (C) 2009-2017 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *#
+<!DOCTYPE html>
+	<html>
+		<head>
+		<meta charset="UTF-8">
+		<title>Versions</title>
+		</head>
+	<body>
+		<table>
+		<tr>
+			<td>webapp version</td>
+			<td>$webappVersion</td>
+		</tr>
+		#foreach ($mapEntry in $depVersions.entrySet())
+			<tr>
+				<td>$mapEntry.getKey()</td>
+				<td>$mapEntry.getValue()</td>
+			</tr>
+		#end
+		</table>
+	</body>
+</html>

--- a/cms-publish-worker-webapp/src/main/webapp/index.jsp
+++ b/cms-publish-worker-webapp/src/main/webapp/index.jsp
@@ -29,7 +29,7 @@
 		</style>
 	</head>
 	<body>
-    	<h2>Simonsoft Worker Webapp</h2>
+    	<h2>SimonsoftCMS Publish Worker</h2>
     	<p class="webappVersion"><a href="rest/info/version">${buildName}</a></p>
     	<p><a href="rest/status">Status</a></p>
     	<p><a href="rest/test/form">Publish Document</a></p>

--- a/cms-publish-worker-webapp/src/main/webapp/index.jsp
+++ b/cms-publish-worker-webapp/src/main/webapp/index.jsp
@@ -19,9 +19,18 @@
 	<head>
 		<meta charset="UTF-8">
 		<title>Simonsoft Worker Webapp</title>
+		<style>
+			.webappVersion {
+				color: grey;
+				font-size: 12px;
+				margin-top: -20px;
+			}
+		
+		</style>
 	</head>
 	<body>
-    	<h2>Simonsoft Worker Webapp</h2>
+    	<h2>Simonsoft Worker Webapp versions</h2>
+    	<p class="webappVersion">${buildName}</p>
     	<p><a href="rest/status">Status</a></p>
     	<p><a href="rest/test/form">Publish Document</a></p>
     	<p><a href="rest/test/publish/job">Publish Job</a></p>

--- a/cms-publish-worker-webapp/src/main/webapp/index.jsp
+++ b/cms-publish-worker-webapp/src/main/webapp/index.jsp
@@ -18,7 +18,7 @@
 <html>
 	<head>
 		<meta charset="UTF-8">
-		<title>Simonsoft Worker Webapp</title>
+		<title>SimonsoftCMS Publish Worker</title>
 		<style>
 			.webappVersion {
 				color: grey;
@@ -29,8 +29,8 @@
 		</style>
 	</head>
 	<body>
-    	<h2>Simonsoft Worker Webapp versions</h2>
-    	<p class="webappVersion">${buildName}</p>
+    	<h2>Simonsoft Worker Webapp</h2>
+    	<p class="webappVersion"><a href="rest/info/version">${buildName}</a></p>
     	<p><a href="rest/status">Status</a></p>
     	<p><a href="rest/test/form">Publish Document</a></p>
     	<p><a href="rest/test/publish/job">Publish Job</a></p>


### PR DESCRIPTION
- Logs version of webapp on start
- Prints webapp version on index page (/worker)
- Logs version of dependencies on start
- Own page to display all versions (/worker/rest/versions)
  - I decided to include it, the code was already written when you decided to print the webapp version on start page.