### PR TITLE
Include cause when caught as exception

### DIFF
--- a/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/AwsStepfunctionPublishWorker.java
+++ b/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/AwsStepfunctionPublishWorker.java
@@ -174,7 +174,7 @@ public class AwsStepfunctionPublishWorker {
 						} catch (IOException | InterruptedException | PublishException e) {
 							updateWorkerError(new Date(), e);
 							logger.error("Exception: " + e.getMessage(), e);
-							sendTaskResult(taskResult, new CommandRuntimeException("JobFailed", e)); // TODO: Consider if e.getMessage() must be set as message on CommandRuntimeException.
+							sendTaskResult(taskResult, new CommandRuntimeException("JobFailed", e));
 							
 						} catch (CommandRuntimeException e) {
 							updateStatusReport("Command failed: " + e.getErrorName(), new Date(), e.getMessage());

--- a/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/AwsStepfunctionPublishWorker.java
+++ b/cms-publish-worker-webapp/src/main/java/se/simonsoft/cms/publish/worker/AwsStepfunctionPublishWorker.java
@@ -184,7 +184,7 @@ public class AwsStepfunctionPublishWorker {
 						} catch (Exception e) {
 							updateWorkerError(new Date(), e);
 							logger.error("Unexpected exception: " + e.getMessage(), e);
-							sendTaskResult(taskResult, new CommandRuntimeException("JobFailed"));
+							sendTaskResult(taskResult, new CommandRuntimeException("JobFailed", e));
 						}
 					} else {
 						


### PR DESCRIPTION
 - Webapp do not wrap Exception in a new CommandRuntimeException. Will AWS throw exception if the message is longer then 10000?