### PR TITLE
Export-publications-filename-bug

### DIFF
--- a/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/PublishResource.java
+++ b/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/PublishResource.java
@@ -18,6 +18,7 @@ package se.simonsoft.cms.publish.rest;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -259,7 +260,7 @@ public class PublishResource {
 		};
 		
 		return Response.ok(stream, MediaType.APPLICATION_OCTET_STREAM)
-				.header("Content-Disposition", "attachment; filename=" + getFilenameDownload(items, publication, releaseItem) + ".zip")
+				.header("Content-Disposition", "attachment; filename=\"" + getFilenameDownload(items, publication, releaseItem) + ".zip\"")
 				.build();
 	}
 	

--- a/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/PublishResource.java
+++ b/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/PublishResource.java
@@ -18,7 +18,6 @@ package se.simonsoft.cms.publish.rest;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;


### PR DESCRIPTION
Downloading files with Export publications in Firefox gave wrong filename if it contained space.
Firefox cut the name at the first space. 
According to https://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1 the filename should be quoted.
Tested in all browsers.