### PR TITLE
Add CDN delivery expiration (days) and jobexpiration-timestamp support

### DIFF
--- a/cms-publish-config/src/main/java/se/simonsoft/cms/publish/config/command/PublishManifestExportCommandHandler.java
+++ b/cms-publish-config/src/main/java/se/simonsoft/cms/publish/config/command/PublishManifestExportCommandHandler.java
@@ -74,7 +74,8 @@ public class PublishManifestExportCommandHandler implements ExternalCommandHandl
 		logger.debug("Requesting export of PublishJob manifest.");
 		String tagStep = "manifest";
 		String tagCdn = ""; // Value length 0 is allowed.
-		
+		String tagExpiration = ""; // Value length 0 is allowed.
+
 		PublishJobProgress progress = options.getProgress();
 		if (progress == null) {
 			throw new IllegalArgumentException("Requires a valid PublishJobProgress object.");
@@ -92,7 +93,11 @@ public class PublishManifestExportCommandHandler implements ExternalCommandHandl
 		if (manifest.getCustom() != null && manifest.getCustom().containsKey("cdn")) {
 			tagCdn = manifest.getCustom().get("cdn");
 		}
-		
+
+		if (options.getDelivery() != null && options.getDelivery().getParams().get("expiration") != null) {
+			tagExpiration = options.getDelivery().getParams().get("expiration") + "d";
+		}
+
 		if (!resultLookup.isPublishResultExists(itemId, options)) {
 			logger.warn("Abort manifest export, publish result does not exist: " + itemId);
 			throw new CommandRuntimeException("PublishResultMissing");
@@ -113,13 +118,13 @@ public class PublishManifestExportCommandHandler implements ExternalCommandHandl
 		}
 		
 		// #1707 Always export the standard manifest as 'index'.
-		doExportManifest(options.getStorage(), new CmsExportItemPublishManifest(writerPublishManifest, manifest), "index.json", tagStep, tagCdn);
-		
+		doExportManifest(options.getStorage(), new CmsExportItemPublishManifest(writerPublishManifest, manifest), "index.json", tagStep, tagCdn, tagExpiration);
+
 		if (manifestCustom) {
 			// TODO: Support custom manifest for local FS. Probably a separate export command (delivery) for both zip and manifest.
 			logger.info("Manifest export suppressed due to custom manifest already in place.");
 		} else {
-			CmsExportWriter exportWriter = doExportManifest(options.getStorage(), exportItem, manifest.getPathext(), tagStep, tagCdn);
+			CmsExportWriter exportWriter = doExportManifest(options.getStorage(), exportItem, manifest.getPathext(), tagStep, tagCdn, tagExpiration);
 			
 			if (exportWriter instanceof CmsExportWriter.LocalFileSystem) {
 				options.getProgress().getParams().put("manifest", ((CmsExportWriter.LocalFileSystem) exportWriter).getExportPath().toString());
@@ -134,12 +139,13 @@ public class PublishManifestExportCommandHandler implements ExternalCommandHandl
 		}
 	}
 	
-	private CmsExportWriter doExportManifest(PublishJobStorage storage, CmsExportItem exportItem, String pathext, String tagStep, String tagCdn) {
-		
+	private CmsExportWriter doExportManifest(PublishJobStorage storage, CmsExportItem exportItem, String pathext, String tagStep, String tagCdn, String tagExpiration) {
+
 		CmsExportJobSingle job = PublishExportJobFactory.getExportJobSingle(storage, pathext);
 		job.addExportItem(exportItem);
 		job.withTagging("PublishStep", tagStep);
 		job.withTagging("PublishCdn", tagCdn);
+		job.withTagging("PublishExpiration", tagExpiration);
 		job.prepare();
 
 		logger.debug("Preparing writer for export...");

--- a/cms-publish-config/src/main/java/se/simonsoft/cms/publish/config/command/PublishManifestExportCommandHandler.java
+++ b/cms-publish-config/src/main/java/se/simonsoft/cms/publish/config/command/PublishManifestExportCommandHandler.java
@@ -74,7 +74,6 @@ public class PublishManifestExportCommandHandler implements ExternalCommandHandl
 		logger.debug("Requesting export of PublishJob manifest.");
 		String tagStep = "manifest";
 		String tagCdn = ""; // Value length 0 is allowed.
-		String tagExpiration = ""; // Value length 0 is allowed.
 
 		PublishJobProgress progress = options.getProgress();
 		if (progress == null) {
@@ -92,10 +91,6 @@ public class PublishManifestExportCommandHandler implements ExternalCommandHandl
 		
 		if (manifest.getCustom() != null && manifest.getCustom().containsKey("cdn")) {
 			tagCdn = manifest.getCustom().get("cdn");
-		}
-
-		if (options.getDelivery() != null && options.getDelivery().getParams().get("expiration") != null) {
-			tagExpiration = options.getDelivery().getParams().get("expiration") + "d";
 		}
 
 		if (!resultLookup.isPublishResultExists(itemId, options)) {
@@ -118,13 +113,13 @@ public class PublishManifestExportCommandHandler implements ExternalCommandHandl
 		}
 		
 		// #1707 Always export the standard manifest as 'index'.
-		doExportManifest(options.getStorage(), new CmsExportItemPublishManifest(writerPublishManifest, manifest), "index.json", tagStep, tagCdn, tagExpiration);
+		doExportManifest(options.getStorage(), new CmsExportItemPublishManifest(writerPublishManifest, manifest), "index.json", tagStep, tagCdn);
 
 		if (manifestCustom) {
 			// TODO: Support custom manifest for local FS. Probably a separate export command (delivery) for both zip and manifest.
 			logger.info("Manifest export suppressed due to custom manifest already in place.");
 		} else {
-			CmsExportWriter exportWriter = doExportManifest(options.getStorage(), exportItem, manifest.getPathext(), tagStep, tagCdn, tagExpiration);
+			CmsExportWriter exportWriter = doExportManifest(options.getStorage(), exportItem, manifest.getPathext(), tagStep, tagCdn);
 			
 			if (exportWriter instanceof CmsExportWriter.LocalFileSystem) {
 				options.getProgress().getParams().put("manifest", ((CmsExportWriter.LocalFileSystem) exportWriter).getExportPath().toString());
@@ -139,13 +134,12 @@ public class PublishManifestExportCommandHandler implements ExternalCommandHandl
 		}
 	}
 	
-	private CmsExportWriter doExportManifest(PublishJobStorage storage, CmsExportItem exportItem, String pathext, String tagStep, String tagCdn, String tagExpiration) {
+	private CmsExportWriter doExportManifest(PublishJobStorage storage, CmsExportItem exportItem, String pathext, String tagStep, String tagCdn) {
 
 		CmsExportJobSingle job = PublishExportJobFactory.getExportJobSingle(storage, pathext);
 		job.addExportItem(exportItem);
 		job.withTagging("PublishStep", tagStep);
 		job.withTagging("PublishCdn", tagCdn);
-		job.withTagging("PublishExpiration", tagExpiration);
 		job.prepare();
 
 		logger.debug("Preparing writer for export...");

--- a/cms-publish-config/src/main/java/se/simonsoft/cms/publish/config/command/PublishManifestJobidCommandHandler.java
+++ b/cms-publish-config/src/main/java/se/simonsoft/cms/publish/config/command/PublishManifestJobidCommandHandler.java
@@ -16,6 +16,9 @@
 package se.simonsoft.cms.publish.config.command;
 
 
+import java.time.Duration;
+import java.time.Instant;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -73,7 +76,9 @@ public class PublishManifestJobidCommandHandler implements ExternalCommandHandle
 		doInsertJobId(manifest, progress);
 		// Augment the manifest with the true StartTime of the execution.
 		doInsertJobStart(manifest, progress);
-		
+		// Augment the manifest with the calculated expiration, when configured.
+		doInsertJobExpiration(manifest, options);
+
 		// Consider deleting manifests (json / index) for restarted jobs.
 		
 		try {
@@ -116,5 +121,26 @@ public class PublishManifestJobidCommandHandler implements ExternalCommandHandle
 		
 		manifest.getJob().put("start", start);
 	}
-	
+
+	/**
+	 * Insert the calculated expiration as manifest.job.expiration, when delivery.params.expiration is configured.
+	 * Same data type as manifest.job.start: an ISO-8601 dateTime string.
+	 * @param manifest
+	 * @param options
+	 */
+	private void doInsertJobExpiration(PublishJobManifest manifest, PublishJobOptions options) {
+
+		if (options.getDelivery() == null) {
+			return;
+		}
+		String expirationDays = options.getDelivery().getParams().get("expiration");
+		if (expirationDays == null) {
+			return;
+		}
+
+		String start = manifest.getJob().get("start");
+		Instant expiration = Instant.parse(start).plus(Duration.ofDays(Long.parseLong(expirationDays)));
+		manifest.getJob().put("expiration", expiration.toString());
+	}
+
 }

--- a/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/PublishJobFactory.java
+++ b/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/PublishJobFactory.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -207,6 +208,16 @@ public class PublishJobFactory {
 			// #1438 Allow suppressing the initial CDN delivery by setting 'version0' to empty string, i.e. keep empty string if set by manifest template.
 			if (custom.get("version0") == null && !custom.get("cdn").equals("preview")) {
 				custom.put("version0", item.getReleaseLabel());
+			}
+
+			// Force a 14-day expiration for Preview CDN, regardless of PublishConfig.
+			if ("preview".equals(custom.get("cdn"))) {
+				Map<String, String> deliveryParams = pj.getOptions().getDelivery().getParams();
+				String expirationConfigured = deliveryParams.get("expiration");
+				if (expirationConfigured != null) {
+					logger.warn("Publish Job with Preview CDN delivery has a configured 'expiration' value ({}) which will be overridden with the forced Preview default (14 days). Config: {}", expirationConfigured, pj.getConfigname());
+				}
+				deliveryParams.put("expiration", "14");
 			}
 		}
 	}

--- a/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/command/PublishPreprocessCommandHandler.java
+++ b/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/command/PublishPreprocessCommandHandler.java
@@ -123,6 +123,10 @@ public class PublishPreprocessCommandHandler implements ExternalCommandHandler<P
 		
 		String tagStep = "preprocess";
 		Optional<String> tagCdn = Optional.empty();
+		Optional<String> tagExpiration = Optional.empty();
+		if (options.getDelivery() != null && options.getDelivery().getParams().get("expiration") != null) {
+			tagExpiration = Optional.of(options.getDelivery().getParams().get("expiration") + "d");
+		}
 
 		if (options.getType() == null) {
 			throw new IllegalArgumentException("Unsupported job type: must not be null");
@@ -192,11 +196,11 @@ public class PublishPreprocessCommandHandler implements ExternalCommandHandler<P
 		LinkedList<CmsExportWriter> result = new LinkedList<CmsExportWriter>();
 
 		CmsExportJob job = PublishExportJobFactory.getExportJobZip(storage, pathext);
-		setTags(job, tagStep, tagCdn, Optional.empty());
+		setTags(job, tagStep, tagCdn, Optional.empty(), tagExpiration);
 		HashMap<String, CmsExportJob> secondaryJobs = new HashMap<>();
 		for (String artifact: this.secondaryExportArtifacts) {
 			CmsExportJob sJob = PublishExportJobFactory.getExportJobZip(storage, artifact + ".zip");
-			setTags(sJob, tagStep, tagCdn, Optional.of(artifact));
+			setTags(sJob, tagStep, tagCdn, Optional.of(artifact), tagExpiration);
 			secondaryJobs.put(artifact, sJob);
 		}
 		secondaryJobs.put("manifest", PublishExportJobFactory.getExportJobSingle(storage, manifestPathext));
@@ -308,11 +312,12 @@ public class PublishPreprocessCommandHandler implements ExternalCommandHandler<P
 		}
 	}
 	
-	private void setTags(CmsExportJob job, String tagStep, Optional<String> tagCdn, Optional<String> tagArtifact) {
+	private void setTags(CmsExportJob job, String tagStep, Optional<String> tagCdn, Optional<String> tagArtifact, Optional<String> tagExpiration) {
 		// S3 accepts and understands the concept of empty tag values, represented with zero-length string.
 		job.withTagging("PublishStep", tagStep);
 		job.withTagging("PublishCdn", tagCdn.orElse(""));
 		job.withTagging("PublishArtifact", tagArtifact.orElse(""));
+		job.withTagging("PublishExpiration", tagExpiration.orElse(""));
 	}
 
 }

--- a/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/command/PublishPreprocessCommandHandler.java
+++ b/cms-publish-rest/src/main/java/se/simonsoft/cms/publish/rest/command/PublishPreprocessCommandHandler.java
@@ -317,7 +317,10 @@ public class PublishPreprocessCommandHandler implements ExternalCommandHandler<P
 		job.withTagging("PublishStep", tagStep);
 		job.withTagging("PublishCdn", tagCdn.orElse(""));
 		job.withTagging("PublishArtifact", tagArtifact.orElse(""));
-		job.withTagging("PublishExpiration", tagExpiration.orElse(""));
+		// Publications without an expiration should not carry the tag at all.
+		if (tagExpiration.isPresent()) {
+			job.withTagging("PublishExpiration", tagExpiration.get());
+		}
 	}
 
 }


### PR DESCRIPTION
Adds delivery.params.expiration (days) as a PublishConfig-configurable
setting, forced to 14 days for Preview CDN with a warning if overridden.
The resolved value is calculated into manifest.job.expiration (an
ISO-8601 timestamp, same type as job.start) once the workflow execution
starts, and tagged onto exported S3 objects as PublishExpiration (e.g.
"14d") alongside the existing PublishStep/PublishCdn/PublishArtifact tags.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WoYzku5tUqcKXJsrH61Cko